### PR TITLE
fix bug: cannot recompile files in cocoapods Pods.xcodeproj

### DIFF
--- a/Source/Classes/Xcode/SFDYCIXCodeHelper.m
+++ b/Source/Classes/Xcode/SFDYCIXCodeHelper.m
@@ -111,7 +111,7 @@
     for (XC(PBXTarget) suggestedTarget in suggested_targets) {
         NSObject *targetObjectID = [(id) suggestedTarget valueForKey:@"objectID"];
         [self.console debug:[NSString stringWithFormat:@"Suggsested target obejct ID %@", targetObjectID]];
-        if ([activeRunContextTargetsIds containsObject:targetObjectID]) {
+        if (targetObjectID) {
             [self.console debug:[NSString stringWithFormat:@"Returning suggested target : %@ == %@", suggestedTarget, targetObjectID]];
             return suggestedTarget;
         }


### PR DESCRIPTION
People use cocoapods heavily in those days.
I use  Local Development Pods to  decouple a big project into several components. 
When I recompile a file in one of those Local Pods, dyci-xcode-plugin will raise an exception:
Recompilation failed Error Domain=com.stanfy.dyci Code=-300 "No recompiler found to handle this file ".

I fixed this issue in this pull request.
